### PR TITLE
Add dependabot for actions and gomod

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    allow:
+      - dependency-type: all


### PR DESCRIPTION
Let's reduce the future maintenance overhead for Auger by setting up weekly automated pr's for go and github actions dependencies via dependabot.