### PR TITLE
Add new workflow for static analysis checks & address lint errors

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -1,0 +1,16 @@
+---
+name: Static analysis
+on: [push, pull_request]
+permissions: read-all
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.21
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v4
+        with:
+          version: v1.57.1

--- a/cmd/decode.go
+++ b/cmd/decode.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"bufio"
@@ -181,7 +180,7 @@ func run(metaOnly bool, outMediaType string, in []byte, out io.Writer) error {
 // Readinput reads command line input, either from a provided input file or from stdin.
 func readInput(inputFilename string) ([]byte, error) {
 	if inputFilename != "" {
-		data, err := ioutil.ReadFile(inputFilename)
+		data, err := os.ReadFile(inputFilename)
 		if err != nil {
 			return nil, fmt.Errorf("error reading input file %s: %v", inputFilename, err)
 		}
@@ -197,7 +196,7 @@ func readInput(inputFilename string) ([]byte, error) {
 		fmt.Fprintln(os.Stderr, "warn: waiting on stdin from tty")
 	}
 
-	stdin, err := ioutil.ReadAll(os.Stdin)
+	stdin, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read data from stdin: %v", err)
 	}

--- a/cmd/decode_test.go
+++ b/cmd/decode_test.go
@@ -18,7 +18,7 @@ package cmd
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"os"
 	"regexp"
 	"strings"
@@ -87,7 +87,7 @@ func readTestFile(t *testing.T, filename string) []byte {
 	if err != nil {
 		t.Fatalf("failed to open test data file: %v", err)
 	}
-	in, err := ioutil.ReadAll(f)
+	in, err := io.ReadAll(f)
 	if err != nil {
 		t.Fatalf("failed to read test data file, %v", err)
 	}

--- a/cmd/extract.go
+++ b/cmd/extract.go
@@ -107,7 +107,7 @@ func init() {
 	extractCmd.Flags().BoolVar(&opts.raw, "raw", false, "Don't attempt to decode the etcd value")
 	extractCmd.Flags().StringVar(&opts.fields, "fields", Key, fmt.Sprintf("Fields to include when listing entries, comma separated list of: %v", SummaryFields))
 	extractCmd.Flags().StringVar(&opts.template, "template", "", fmt.Sprintf("golang template to use when listing entries, see https://golang.org/pkg/text/template, template is provided an object with the fields: %v. The Value field contains the entire kubernetes resource object which also may be dereferenced using a dot seperated path.", templateFields()))
-	extractCmd.Flags().StringVar(&opts.filter, "filter", "", fmt.Sprintf("Filter entries using a comma separated list of '<field>=value' constraints. Fields used in filters use the same naming as --template fields, e.g. .Value.metadata.namespace"))
+	extractCmd.Flags().StringVar(&opts.filter, "filter", "", "Filter entries using a comma separated list of '<field>=value' constraints. Fields used in filters use the same naming as --template fields, e.g. .Value.metadata.namespace")
 }
 
 const (
@@ -319,7 +319,7 @@ func summarize(s *data.KeySummary, fields []string) (string, error) {
 	for i, field := range fields {
 		switch field {
 		case Key:
-			values[i] = fmt.Sprintf("%s", s.Key)
+			values[i] = s.Key
 		case ValueSize:
 			values[i] = fmt.Sprintf("%d", s.Stats.ValueSize)
 		case AllVersionsValueSize:
@@ -327,7 +327,7 @@ func summarize(s *data.KeySummary, fields []string) (string, error) {
 		case VersionCount:
 			values[i] = fmt.Sprintf("%d", s.Stats.VersionCount)
 		case Value:
-			values[i] = fmt.Sprintf("%s", s.ValueJson())
+			values[i] = s.ValueJson()
 		default:
 			return "", fmt.Errorf("unrecognized field: %s", field)
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,8 +23,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var cfgFile string
-
 var RootCmd = &cobra.Command{
 	Use:   "auger",
 	Short: "Inspect and analyze kubernetes storage data.",

--- a/pkg/encoding/encoding.go
+++ b/pkg/encoding/encoding.go
@@ -250,7 +250,9 @@ func decodeTypeMeta(inMediaType string, in []byte) (*runtime.TypeMeta, error) {
 
 func typeMetaFromJson(in []byte) (*runtime.TypeMeta, error) {
 	var meta runtime.TypeMeta
-	json.Unmarshal(in, &meta)
+	if err := json.Unmarshal(in, &meta); err != nil {
+		return nil, err
+	}
 	return &meta, nil
 }
 
@@ -264,6 +266,8 @@ func typeMetaFromBinaryStorage(in []byte) (*runtime.TypeMeta, error) {
 
 func typeMetaFromYaml(in []byte) (*runtime.TypeMeta, error) {
 	var meta runtime.TypeMeta
-	yaml.Unmarshal(in, &meta)
+	if err := yaml.Unmarshal(in, &meta); err != nil {
+		return nil, err
+	}
 	return &meta, nil
 }

--- a/pkg/encoding/encoding_test.go
+++ b/pkg/encoding/encoding_test.go
@@ -28,7 +28,7 @@ var findProtoTests = []struct {
 }{
 	{string(ProtoEncodingPrefix), true, string(ProtoEncodingPrefix)},
 	{fmt.Sprintf("xxxxxx%s...end", ProtoEncodingPrefix), true, fmt.Sprintf("%s...end", ProtoEncodingPrefix)},
-	{fmt.Sprintf("xxxxxx{}"), false, ""},
+	{"xxxxxx{}", false, ""},
 }
 
 func TestTryFindProto(t *testing.T) {

--- a/pkg/encoding/scheme.go
+++ b/pkg/encoding/scheme.go
@@ -98,6 +98,7 @@ func init() {
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.
+//nolint:errcheck
 func AddToScheme(scheme *runtime.Scheme) {
 	admissionv1beta1.AddToScheme(scheme)
 


### PR DESCRIPTION
This pull request introduces a basic new github actions workflow for running `golangci-lint` so we can keep on top of this moving forward.

In a second commit I've also quickly gone through all the lint errors and made an initial rushed attempt at fixing them, @siyuanfoundation can you please take a close look at these.