### PR TITLE
chore: update go version to use go.mod as go-version-file.

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version-file: go.mod
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,10 +7,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21
-      - uses: actions/checkout@v4
+          go-version-file: go.mod
       - name: tests
         run: |
           make test


### PR DESCRIPTION

after https://github.com/etcd-io/auger/pull/44, go version update to 1.22.0, this PR is working for update go version of ci

cc @siyuanfoundation 