### PR TITLE
Explicitly convert inMediaType json to outMediaType yaml

### DIFF
--- a/pkg/encoding/encoding.go
+++ b/pkg/encoding/encoding.go
@@ -98,11 +98,11 @@ func Convert(codecs serializer.CodecFactory, inMediaType, outMediaType string, i
 	} else if inMediaType == JsonMediaType && outMediaType == YamlMediaType {
 		val := map[string]interface{}{}
 		if err := json.Unmarshal(in, &val); err != nil {
-			return nil, fmt.Errorf("error decoding from %s: %s", inMediaType, err)
+			return nil, nil, fmt.Errorf("error decoding from %s: %s", inMediaType, err)
 		}
 		encoded, err = yaml.Marshal(val)
 		if err != nil {
-			return nil, fmt.Errorf("error encoding from %s: %s", outMediaType, err)
+			return nil, nil, fmt.Errorf("error encoding from %s: %s", outMediaType, err)
 		}
 	} else {
 		inCodec, err := newCodec(codecs, typeMeta, inMediaType)

--- a/pkg/encoding/encoding.go
+++ b/pkg/encoding/encoding.go
@@ -95,6 +95,15 @@ func Convert(codecs serializer.CodecFactory, inMediaType, outMediaType string, i
 		if outMediaType == JsonMediaType {
 			encoded = append(encoded, '\n')
 		}
+	} else if inMediaType == JsonMediaType && outMediaType == YamlMediaType {
+		val := map[string]interface{}{}
+		if err := json.Unmarshal(in, &val); err != nil {
+			return nil, fmt.Errorf("error decoding from %s: %s", inMediaType, err)
+		}
+		encoded, err = yaml.Marshal(val)
+		if err != nil {
+			return nil, fmt.Errorf("error encoding from %s: %s", outMediaType, err)
+		}
 	} else {
 		inCodec, err := newCodec(codecs, typeMeta, inMediaType)
 		if err != nil {


### PR DESCRIPTION
> CRDs currently can be read with --output=json and that is generally how it is encoded in k8s as well. I think there are discussions regarding other encoders for CRDs. Until that changes, we do not really need to worry about that. However we do need to add better documentation of how to decode CRDs.

Since you mentioned in [#33 ](url) that CRDs can be read using `--output=json,` I believe this indicates that auger is functionally capable of correctly accessing data in the `application/json` format (similarly for other data types like CRDs which are also in `application/json` format). Therefore, I think that when attempting to read this data without the `--output=json` parameter, the output `error decoding from application/json: xxxx` is an unfriendly of program logic, because this data can indeed be accessed normally and should not throw an error.
I modified the logic in `encoding.go` so that when `inMediaType` is `json` and `outMediaType` is `yaml`(the default case), it explicitly converts the `json` data to `yaml` format for output. 
