### PR TITLE
Bump golang to latest patch release 1.22.4.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.21-alpine
+FROM docker.io/golang:1.22-alpine
 
 RUN apk add --no-cache curl git make && rm -rf /var/cache/apk/*
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 
 NAME ?= auger
 PKG ?= github.com/etcd-io/$(NAME)
-GO_VERSION ?= 1.21.8
+GO_VERSION ?= 1.22.4
 GOOS ?= linux
 GOARCH ?= amd64
 TEMP_DIR := $(shell mktemp -d)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/etcd-io/auger
 
-go 1.22.0
+go 1.22.4
 
 require (
 	github.com/google/safetext v0.0.0-20220914124124-e18e3fe012bf


### PR DESCRIPTION
Keep auger in sync with rest of etcd project repositories.