### PR TITLE
Bump go & golangci-lint and pin actions dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,8 @@ updates:
       interval: weekly
     allow:
       - dependency-type: all
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
         with:
-          version: v1.57.1
+          version: v1.59.1
           args: --config tools/.golangci.yaml
       - run: |
           set -euo pipefail

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -6,12 +6,12 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
           go-version-file: go.mod
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
         with:
           version: v1.57.1
           args: --config tools/.golangci.yaml

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,8 +7,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
           go-version-file: go.mod
       - name: tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.22-alpine
+FROM docker.io/golang@sha256:58e52f6ddd39098d23b1a34ec24024acd5fe182245960afe572d83c313aafbed
 
 RUN apk add --no-cache curl git make && rm -rf /var/cache/apk/*
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 
 NAME ?= auger
 PKG ?= github.com/etcd-io/$(NAME)
-GO_VERSION ?= 1.22.4
+GO_VERSION ?= 1.22.6
 GOOS ?= linux
 GOARCH ?= amd64
 TEMP_DIR := $(shell mktemp -d)

--- a/README.md
+++ b/README.md
@@ -114,10 +114,3 @@ auger checksum -f <member-3-boltdb-file> -r 7
 > revision: 7
 # Oh noes! The checksum should have been the same!
 ```
-
-## TODO
-
-- [ ] Warn if attempting to read data written by a different version of kubernetes
-- [ ] Add detection of unrecognized fields in stored data, which would suggest
-      data was written with newer version of proto schema
-- [ ] Build and publish releases for all recent kubernetes versions (1.6+)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Auger
------
+# Auger
 
 Directly access data objects stored in `etcd` by `kubernetes`.
 
@@ -9,8 +8,7 @@ store data to `etcd`. Supports data conversion to `YAML`, `JSON` and `Protobuf`.
 Automatically determines if etcd data is stored in `JSON` (`kubernetes` `1.5` and
 earlier) or binary (`kubernetes` `1.6` and newer) and decodes accordingly.
 
-Why?
-----
+## Why?
 
 In earlier versions of `kubernetes`, data written to `etcd` was stored as `JSON`
 and could easily be inspected or manipulated using standard tools such as
@@ -21,8 +19,7 @@ contains a enveloped payload that must be unpacked, type resolved and decoded.
 This tool provides `kubernetes` developers and cluster operators with simple way
 to access the binary storage data via `YAML` and `JSON`.
 
-Installation
-------------
+## Installation
 
 Check out and build:
 
@@ -34,13 +31,11 @@ make release
 
 Run:
 
-
 ```sh
 build/auger -h
 ```
 
-Use cases
----------
+## Use cases
 
 ### Access data via etcdctl
 
@@ -120,8 +115,7 @@ auger checksum -f <member-3-boltdb-file> -r 7
 # Oh noes! The checksum should have been the same!
 ```
 
-TODO
-----
+## TODO
 
 - [ ] Warn if attempting to read data written by a different version of kubernetes
 - [ ] Add detection of unrecognized fields in stored data, which would suggest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/etcd-io/auger
 
-go 1.22.4
+go 1.22.6
 
 require (
 	github.com/google/safetext v0.0.0-20220914124124-e18e3fe012bf


### PR DESCRIPTION
Some quick maintenance while I had a moment spare today:

- **Update to latest go patch release 1.22.6.**
- **Pin github actions dependencies by commit sha.**
- **Bump golangci-lint version to align with etcd-io/etcd.**
- **Resolve markdownlint issues in README.md.**
