### PR TITLE
Move the go directive version to toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/etcd-io/auger
 
-go 1.22.6
+go 1.22.0
+
+toolchain go1.22.6
 
 require (
 	github.com/google/safetext v0.0.0-20220914124124-e18e3fe012bf


### PR DESCRIPTION
The go directive from the `go.mod` file should be set to the minimum version required to compile packages from the module, and use `toolchain` to specify the latest go version [2].

This project's code should work fine with any version greater than 1.22. It will prevent projects that depend on this package from getting a go directive version bump every time there's a new version of this dependency.

Please see a similar issue we had during the etcd dependency update [1].

Reference:
[1] https://github.com/etcd-io/etcd/pull/18418#discussion_r1709929410 
[2] https://github.com/alexfalkowski/gocovmerge/pull/87