### PR TITLE
Revert "Bump golang from `d0b3155` to `613a108`"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang@sha256:613a108a4a4b1dfb6923305db791a19d088f77632317cfc3446825c54fb862cd
+FROM docker.io/golang@sha256:d0b31558e6b3e4cc59f6011d79905835108c919143ebecc58f35965bf79948f4
 
 RUN apk add --no-cache curl git make && rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
Reverts etcd-io/auger#97.  