### PR TITLE
Added CGO_ENABLED=0 to build args

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ GOOS ?= linux
 GOARCH ?= amd64
 TEMP_DIR := $(shell mktemp -d)
 GOFILES = $(shell find . -name \*.go)
+CGO_ENABLED ?= 0
 
 .PHONY: fmt
 fmt:
@@ -36,7 +37,7 @@ verify:
 # Local development build
 build:
 	@mkdir -p build
-	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o build/$(NAME)
+	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=$(CGO_ENABLED) go build -o build/$(NAME)
 	@echo build/$(NAME) built!
 
 # Local development test
@@ -63,7 +64,7 @@ release:
 # Build used inside docker by 'release'
 release-docker-build:
 	export GOPATH=/go
-	GOOS=$(GOOS) GOARCH=$(GOARCH) GO111MODULE=on go build
+	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=$(CGO_ENABLED) GO111MODULE=on go build
 
 clean:
 	rm -rf build

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ release:
 		-v $(TEMP_DIR)/$(NAME):/go/src/$(PKG) \
 		-w /go/src/$(PKG) \
 		golang:$(GO_VERSION) \
-		/bin/bash -c "make -f /go/src/$(PKG)/Makefile release-docker-build GOARCH=$(GOARCH) GOOS=$(GOOS)"
+		/bin/bash -c "make -f /go/src/$(PKG)/Makefile release-docker-build GOARCH=$(GOARCH) GOOS=$(GOOS) CGO_ENABLED=$(CGO_ENABLED)"
 	@mkdir -p build
 	@cp $(TEMP_DIR)/$(NAME)/$(NAME) build/$(NAME)
 	@echo build/$(NAME) built!


### PR DESCRIPTION
I got error:
`auger: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by auger)`
On my Ubuntu after building auger, adding CGO_ENABLED=0 to build env vars solved the problem. I'm not a Go expert but it did just solve my issue.

# This is an improvement to prior PR: https://github.com/etcd-io/auger/pull/103