### PR TITLE
goreleaser based release build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
       - run: git fetch --force --tags
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: '1.23.1'
+          go-version-file: go.mod
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 #v6.0.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: MIT
+
+name: release
+
+on:
+  push:
+    # run only against tags
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          fetch-depth: 0
+
+      - run: git fetch --force --tags
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version: '1.23.1'
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 #v6.0.0
+        with:
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ vendor
 *.dylib
 coverage.html
 .glide/
+# goreleaser builds
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: MIT
+version: 2
+project_name: auger
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - id: auger
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X github.com/etcd-id/auger/cmd.appVersion={{.Version}}
+      - -X github.com/etcd-id/auger/cmd.buildDate={{.Date}}
+      - -X github.com/etcd-id/auger/cmd.gitCommit={{.Commit}}
+    main: ./main.go
+    binary: auger
+  - id: augerctl
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X github.com/etcd-id/auger/command.appVersion={{.Version}}
+      - -X github.com/etcd-id/auger/command.buildDate={{.Date}}
+      - -X github.com/etcd-id/auger/command.gitCommit={{.Commit}}
+    main: ./augerctl/main.go
+    binary: augerctl
+
+archives:
+  - builds:
+      - auger
+      - augerctl
+
+checksum:
+  name_template: "checksums.txt"
+changelog:
+  sort: asc
+  use: github
+  groups:
+    - title: "✨ Features"
+      regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
+      order: 0
+    - title: "🐛 Bug fixes"
+      regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
+      order: 1
+    - title: "📚 Documentation"
+      regexp: '^.*?docs(\([[:word:]]+\))??!?:.+$'
+      order: 2
+    - title: "🌱 Others"
+      order: 999
+  filters:
+    exclude:
+      - "^test:"
+release:
+  github:
+    owner: etcd-io
+    name: auger
+  prerelease: auto

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -49,16 +49,16 @@ changelog:
   sort: asc
   use: github
   groups:
-    - title: "✨ Features"
+    - title: "Features"
       regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
       order: 0
-    - title: "🐛 Bug fixes"
+    - title: "Bug fixes"
       regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
       order: 1
-    - title: "📚 Documentation"
+    - title: "Documentation"
       regexp: '^.*?docs(\([[:word:]]+\))??!?:.+$'
       order: 2
-    - title: "🌱 Others"
+    - title: "Others"
       order: 999
   filters:
     exclude:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,6 @@
 
 The Auger Project is released on an as-needed basis. The process is as follows:
 
-1. An issue is proposing a new release with a changelog since the last release
-1. A quorum of [OWNERS](OWNERS) must LGTM this release
-1. An OWNER runs `git tag -s $VERSION` and inserts the changelog and pushes the tag with `git push $VERSION`
-1. The release issue is closed
+1. Create a new git tag with `git tag -s $VERSION`
+1. Push the tag with `git push $VERSION`
+1. Once pushed, the [github workflow](.github/workflows/release.yaml) will automatically create a new release with the tag and changelog.

--- a/augerctl/command/ctl.go
+++ b/augerctl/command/ctl.go
@@ -55,5 +55,6 @@ func NewCtlCommand() *cobra.Command {
 	cmd.AddCommand(
 		newCtlGetCommand(flags),
 	)
+	cmd.AddCommand(versionCmd)
 	return cmd
 }

--- a/augerctl/command/version.go
+++ b/augerctl/command/version.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package command
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/spf13/cobra"
+)
+
+// Version information
+var (
+	// AppVersion is the version of the application
+	appVersion = "v0.0.0-dev"
+
+	// BuildTime is the time the application was built
+	buildDate = "1970-01-01T00:00:00Z" // build date in ISO8601 format
+
+	// GitCommit is the commit hash of the build
+	gitCommit string
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "print current version",
+	Run: func(_ *cobra.Command, _ []string) {
+		fmt.Printf("Version:\t%s\n", appVersion)
+		fmt.Printf("BuildTime:\t%s\n", buildDate)
+		fmt.Printf("GitCommit:\t%s\n", gitCommit)
+		fmt.Printf("GoVersion:\t%s\n", runtime.Version())
+		fmt.Printf("Compiler:\t%s\n", runtime.Compiler)
+		fmt.Printf("OS/Arch:\t%s/%s\n", runtime.GOOS, runtime.GOARCH)
+	},
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/spf13/cobra"
+)
+
+// Version information
+var (
+	// AppVersion is the version of the application
+	appVersion = "v0.0.0-dev"
+
+	// BuildTime is the time the application was built
+	buildDate = "1970-01-01T00:00:00Z" // build date in ISO8601 format
+
+	// GitCommit is the commit hash of the build
+	gitCommit string
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "print current version",
+	Run: func(_ *cobra.Command, _ []string) {
+		fmt.Printf("Version:\t%s\n", appVersion)
+		fmt.Printf("BuildTime:\t%s\n", buildDate)
+		fmt.Printf("GitCommit:\t%s\n", gitCommit)
+		fmt.Printf("GoVersion:\t%s\n", runtime.Version())
+		fmt.Printf("Compiler:\t%s\n", runtime.Compiler)
+		fmt.Printf("OS/Arch:\t%s/%s\n", runtime.GOOS, runtime.GOARCH)
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(versionCmd)
+}


### PR DESCRIPTION
closes #28

This will add a `goreleaser` based release process as described in the updated `RELEASE.md`

An example release with artifacts can be seen here: https://github.com/bavarianbidi/auger/releases/tag/v0.1.0

https://github.com/bavarianbidi/auger/actions/runs/11392186824/job/31697673348 will give you the github actions output of the release process, produced by `goreleaser`.