### PR TITLE
[main] Bump go toolchain to 1.23.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 
 NAME ?= auger
 PKG ?= github.com/etcd-io/$(NAME)
-GO_VERSION ?= 1.23.1
+GO_VERSION ?= 1.23.2
 GOOS ?= linux
 GOARCH ?= amd64
 TEMP_DIR := $(shell mktemp -d)

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/etcd-io/auger
 
 go 1.23
 
-toolchain go1.23.1
+toolchain go1.23.2
 
 require (
 	github.com/google/safetext v0.0.0-20220914124124-e18e3fe012bf


### PR DESCRIPTION
Reference:
- https://github.com/etcd-io/etcd/issues/18665