### PR TITLE
Ensure desired golang image tag is specified

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang@sha256:d0b31558e6b3e4cc59f6011d79905835108c919143ebecc58f35965bf79948f4
+FROM docker.io/golang:1.23-alpine@sha256:d0b31558e6b3e4cc59f6011d79905835108c919143ebecc58f35965bf79948f4
 
 RUN apk add --no-cache curl git make && rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
This should fix depdendabot being able to suggest the correct new image for auger and resolve the issue we initially saw back in https://github.com/etcd-io/auger/pull/97#issuecomment-2299884674.

cc @ivanvc  