### PR TITLE
fix: correct the build args version injection

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,9 +16,9 @@ builds:
       - arm64
     ldflags:
       - -s -w
-      - -X github.com/etcd-id/auger/cmd.appVersion={{.Version}}
-      - -X github.com/etcd-id/auger/cmd.buildDate={{.Date}}
-      - -X github.com/etcd-id/auger/cmd.gitCommit={{.Commit}}
+      - -X github.com/etcd-io/auger/cmd.appVersion={{.Version}}
+      - -X github.com/etcd-io/auger/cmd.buildDate={{.Date}}
+      - -X github.com/etcd-io/auger/cmd.gitCommit={{.Commit}}
     main: ./main.go
     binary: auger
   - id: augerctl
@@ -32,9 +32,9 @@ builds:
       - arm64
     ldflags:
       - -s -w
-      - -X github.com/etcd-id/auger/command.appVersion={{.Version}}
-      - -X github.com/etcd-id/auger/command.buildDate={{.Date}}
-      - -X github.com/etcd-id/auger/command.gitCommit={{.Commit}}
+      - -X github.com/etcd-io/auger/augerctl/command.appVersion={{.Version}}
+      - -X github.com/etcd-io/auger/augerctl/command.buildDate={{.Date}}
+      - -X github.com/etcd-io/auger/augerctl/command.gitCommit={{.Commit}}
     main: ./augerctl/main.go
     binary: augerctl
 


### PR DESCRIPTION
the build args contain a typo in the path to set the version, git commit sha and build time.

And therefore the version information is wrong:

```bash
auger version
Version:        v0.0.0-dev
BuildTime:      1970-01-01T00:00:00Z
GitCommit:
GoVersion:      go1.23.3
Compiler:       gc
OS/Arch:        linux/amd64

augerctl version
Version:        v0.0.0-dev
BuildTime:      1970-01-01T00:00:00Z
GitCommit:
GoVersion:      go1.23.3
Compiler:       gc
```

this PR fixes the issue and add correct version information (tested with a fake `v1.0.3` version on my fork):

```bash
auger version                                                                                                                             Version:        1.0.3
BuildTime:      2024-11-18T13:26:07Z
GitCommit:      b4b18c70baadd8f9a2cc375faf6a8a58d19971c5
GoVersion:      go1.23.3
Compiler:       gc
OS/Arch:        linux/amd64

augerctl version
Version:        1.0.3
BuildTime:      2024-11-18T13:26:07Z
GitCommit:      b4b18c70baadd8f9a2cc375faf6a8a58d19971c5
GoVersion:      go1.23.3
Compiler:       gc
OS/Arch:        linux/amd64
```