### PR TITLE
Update auger golang toolchain to 1.23.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/etcd-io/auger
 
 go 1.23
 
-toolchain go1.23.4
+toolchain go1.23.5
 
 require (
 	github.com/google/safetext v0.0.0-20220914124124-e18e3fe012bf


### PR DESCRIPTION
Updates auger golang toolchain from `1.23.4` to `1.23.5`

Subtask from Issue: https://github.com/etcd-io/etcd/issues/19210

Verified as:
```
make build
make test
```