### PR TITLE
Bump go linter 1.24

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@2e788936b09dd82dc280e845628a40d2ba6b204c # v6.3.1
         with:
-          version: v1.60.1
+          version: v1.63.4
           args: --config tools/.golangci.yaml
       - run: |
           set -euo pipefail


### PR DESCRIPTION
https://github.com/etcd-io/auger/pull/208 CI failure is due to linter version used is built using go1.23.

This PR bumps the go-linter version used in CI

@ivanvc @henrybear327