### PR TITLE
chore: enable more rules from revive

### DIFF
--- a/augerctl/command/global.go
+++ b/augerctl/command/global.go
@@ -18,7 +18,7 @@ package command
 
 import (
 	"crypto/tls"
-	"fmt"
+	"errors"
 	"strings"
 
 	"github.com/etcd-io/auger/pkg/client"
@@ -70,7 +70,7 @@ func clientConfigFromCmd(f *flagpole) (clientv3.Config, error) {
 		if f.Password == "" {
 			splitted := strings.SplitN(f.User, ":", 2)
 			if len(splitted) < 2 {
-				return clientv3.Config{}, fmt.Errorf("password is missing")
+				return clientv3.Config{}, errors.New("password is missing")
 			}
 			cfg.Username = splitted[0]
 			cfg.Password = splitted[1]

--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -28,7 +28,7 @@ import (
 var analyzeCmd = &cobra.Command{
 	Use:   "analyze",
 	Short: "Analyze kubernetes data from the boltdb '.db' files etcd persists to.",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		return analyzeValidateAndRun()
 	},
 }

--- a/cmd/checksum.go
+++ b/cmd/checksum.go
@@ -26,7 +26,7 @@ import (
 var checksumCmd = &cobra.Command{
 	Use:   "checksum",
 	Short: "Checksum a etcd keyspace.",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		return checksum()
 	},
 }

--- a/cmd/decode.go
+++ b/cmd/decode.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -62,7 +63,7 @@ var decodeCmd = &cobra.Command{
 	Short:   "Decode objects from the kubernetes binary key-value store encoding.",
 	Long:    decodeLong,
 	Example: decodeExample,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		return validateAndRun()
 	},
 }
@@ -97,7 +98,7 @@ func validateAndRun() error {
 
 	in, err := readInput(options.inputFilename)
 	if len(in) == 0 {
-		return fmt.Errorf("no input data")
+		return errors.New("no input data")
 	}
 	if err != nil {
 		return err

--- a/cmd/encode.go
+++ b/cmd/encode.go
@@ -17,7 +17,7 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
+	"errors"
 	"io"
 	"os"
 
@@ -42,7 +42,7 @@ var encodeCmd = &cobra.Command{
 	Short:   "Encode objects to the kubernetes binary key-value store encoding.",
 	Long:    encodeLong,
 	Example: encodeExample,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		return encodeValidateAndRun()
 	},
 }
@@ -70,7 +70,7 @@ func encodeValidateAndRun() error {
 
 	in, err := readInput(encodeOpts.inputFilename)
 	if len(in) == 0 {
-		return fmt.Errorf("no input data")
+		return errors.New("no input data")
 	}
 	if err != nil {
 		return err

--- a/cmd/extract.go
+++ b/cmd/extract.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -70,7 +71,7 @@ var extractCmd = &cobra.Command{
 	Short:   "Extracts kubernetes data from the boltdb '.db' files etcd persists to.",
 	Long:    extractLong,
 	Example: extractExample,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		return extractValidateAndRun()
 	},
 }
@@ -160,17 +161,17 @@ func extractValidateAndRun() error {
 		}
 		return printLeafItemValue(kv, outMediaType, out)
 	case hasKey && hasKeyPrefix:
-		return fmt.Errorf("--keys-by-prefix and --key may not be used together")
+		return errors.New("--keys-by-prefix and --key may not be used together")
 	case hasKey && opts.listVersions:
 		return printVersions(opts.filename, opts.key, out)
 	case hasKey:
 		return printValue(opts.filename, opts.key, opts.version, opts.raw, outMediaType, out)
 	case !hasKey && opts.listVersions:
-		return fmt.Errorf("--list-versions may only be used with --key")
+		return errors.New("--list-versions may only be used with --key")
 	case !hasKey && hasVersion:
-		return fmt.Errorf("--version may only be used with --key")
+		return errors.New("--version may only be used with --key")
 	case hasTemplate && hasFields:
-		return fmt.Errorf("--template and --fields may not be used together")
+		return errors.New("--template and --fields may not be used together")
 	case hasTemplate:
 		return printTemplateSummaries(opts.filename, opts.keyPrefix, opts.revision, opts.template, opts.filter, out)
 	default:
@@ -216,7 +217,7 @@ func printValue(filename string, key string, version string, raw bool, outMediaT
 		return err
 	}
 	if len(in) == 0 {
-		return fmt.Errorf("0 byte value")
+		return errors.New("0 byte value")
 	}
 	if raw {
 		fmt.Fprintf(out, "%s\n", string(in))
@@ -259,7 +260,7 @@ func printLeafItemValue(kv *mvccpb.KeyValue, outMediaType string, out io.Writer)
 // printKeySummaries prints all keys in the db file with the given key prefix.
 func printKeySummaries(filename string, keyPrefix string, revision int64, fields []string, out io.Writer) error {
 	if len(fields) == 0 {
-		return fmt.Errorf("no fields provided, nothing to output")
+		return errors.New("no fields provided, nothing to output")
 	}
 
 	var hasKey bool
@@ -297,7 +298,7 @@ func printTemplateSummaries(filename string, keyPrefix string, revision int64, t
 	}
 
 	if len(templatestr) == 0 {
-		return fmt.Errorf("no template provided, nothing to output")
+		return errors.New("no template provided, nothing to output")
 	}
 
 	filters := []data.Filter{}

--- a/pkg/client/client_get.go
+++ b/pkg/client/client_get.go
@@ -18,19 +18,19 @@ package client
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 func (c *client) Get(ctx context.Context, prefix string, opOpts ...OpOption) (rev int64, err error) {
 	if prefix == "" {
-		return 0, fmt.Errorf("prefix is required")
+		return 0, errors.New("prefix is required")
 	}
 
 	opt := opOption(opOpts)
 	if opt.response == nil {
-		return 0, fmt.Errorf("response is required")
+		return 0, errors.New("response is required")
 	}
 
 	path, single, err := getPrefix(prefix, opt.gr, opt.name, opt.namespace)

--- a/pkg/client/util.go
+++ b/pkg/client/util.go
@@ -17,7 +17,7 @@ limitations under the License.
 package client
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -42,7 +42,7 @@ var specialDefaultMediaTypes = map[string]struct{}{
 // prefixFromGR returns the prefix of the given GroupResource.
 func prefixFromGR(gr schema.GroupResource) (string, error) {
 	if gr.Resource == "" {
-		return "", fmt.Errorf("resource is empty")
+		return "", errors.New("resource is empty")
 	}
 
 	if prefix, ok := specialDefaultResourcePrefixes[gr]; ok {
@@ -80,7 +80,7 @@ func getPrefix(prefix string, gr schema.GroupResource, name, namespace string) (
 
 	if gr.Empty() {
 		if namespace != "" || name != "" {
-			return "", false, fmt.Errorf("namespace and name must be omitted if there is no GroupResource")
+			return "", false, errors.New("namespace and name must be omitted if there is no GroupResource")
 		}
 	} else {
 		p, err := prefixFromGR(gr)

--- a/pkg/encoding/encoding.go
+++ b/pkg/encoding/encoding.go
@@ -19,6 +19,7 @@ package encoding
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 
@@ -80,7 +81,7 @@ func Convert(codecs serializer.CodecFactory, inMediaType, outMediaType string, i
 	}
 
 	if inMediaType == ProtobufMediaType && outMediaType == StorageBinaryMediaType {
-		return nil, nil, fmt.Errorf("unsupported conversion: protobuf to kubernetes binary storage representation")
+		return nil, nil, errors.New("unsupported conversion: protobuf to kubernetes binary storage representation")
 	}
 
 	typeMeta, err := DecodeTypeMeta(inMediaType, in)
@@ -96,7 +97,7 @@ func Convert(codecs serializer.CodecFactory, inMediaType, outMediaType string, i
 			encoded = append(encoded, '\n')
 		}
 	} else if inMediaType == JsonMediaType && outMediaType == YamlMediaType {
-		val := map[string]interface{}{}
+		val := map[string]any{}
 		if err := json.Unmarshal(in, &val); err != nil {
 			return nil, nil, fmt.Errorf("error decoding from %s: %s", inMediaType, err)
 		}
@@ -140,7 +141,7 @@ func DetectAndExtract(in []byte) (string, []byte, error) {
 		}
 		return JsonMediaType, js, nil
 	}
-	return "", nil, fmt.Errorf("error reading input, does not appear to contain valid JSON or binary data")
+	return "", nil, errors.New("error reading input, does not appear to contain valid JSON or binary data")
 }
 
 // TryFindProto searches for the 'k8s\0' prefix, and, if found, returns the data starting with the prefix.

--- a/pkg/scheme/init.go
+++ b/pkg/scheme/init.go
@@ -17,7 +17,7 @@ limitations under the License.
 package scheme
 
 import (
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -27,6 +27,6 @@ var Scheme = runtime.NewScheme()
 var Codecs = serializer.NewCodecFactory(Scheme)
 
 func init() {
-	v1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
+	metav1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
 	AddToScheme(Scheme)
 }

--- a/tools/.golangci.yaml
+++ b/tools/.golangci.yaml
@@ -17,6 +17,7 @@ linters:
     # - structcheck
     # - varcheck
     - goimports
+    - importas
     - ineffassign
     - nakedret
     - revive
@@ -28,6 +29,10 @@ linters:
 linters-settings: # please keep this alphabetized
   goimports:
     local-prefixes: go.etcd.io # Put imports beginning with prefix after 3rd-party packages.
+  importas:
+    alias:
+      - alias: metav1
+        pkg: k8s.io/apimachinery/pkg/apis/meta/v1
   nakedret:
     # Align with https://github.com/alexkohler/nakedret/blob/v1.0.2/cmd/nakedret/main.go#L10
     max-func-lines: 5
@@ -54,9 +59,16 @@ linters-settings: # please keep this alphabetized
       - name: indent-error-flow
         arguments:
           - "preserveScope"
+      - name: receiver-naming
+      - name: redundant-import-alias
       - name: superfluous-else
         arguments:
           - "preserveScope"
+      - name: unnecessary-stmt
+      - name: unused-parameter
+      - name: use-any
+      - name: use-errors-new
+      - name: useless-break
       - name: var-declaration
       # TODO: enable the following rules
       - name: var-naming


### PR DESCRIPTION
enable the following rules from revive :
* receiver-naming
* redundant-import-alias
* unnecessary-stmt
* unused-parameter
* use-any
* use-errors-new
* useless-break 