### PR TITLE
Update golang toolchain to version 1.24.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/etcd-io/auger
 
 go 1.24
 
-toolchain go1.24.0
+toolchain go1.24.1
 
 require (
 	github.com/google/safetext v0.0.0-20220914124124-e18e3fe012bf


### PR DESCRIPTION
Updating golang toolchain to version 1.24.1

Subtask of https://github.com/etcd-io/etcd/issues/19524

Verified with

```
make build
make test`