### PR TITLE
Bump go toolchain to v1.24.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.24-alpine@sha256:7772cb5322baa875edd74705556d08f0eeca7b9c4b5367754ce3f2f00041ccee
+FROM docker.io/golang:1.24.2-alpine@sha256:7772cb5322baa875edd74705556d08f0eeca7b9c4b5367754ce3f2f00041ccee
 
 RUN apk add --no-cache curl git make && rm -rf /var/cache/apk/*
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/etcd-io/auger
 
 go 1.24
 
+toolchain go1.24.2
+
 require (
 	github.com/google/safetext v0.0.0-20220914124124-e18e3fe012bf
 	github.com/spf13/cobra v1.9.1


### PR DESCRIPTION
Reference https://github.com/etcd-io/etcd/issues/19713