### PR TITLE
chore: remove note in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,6 @@ build:
 
 
 # Local development test
-# `go test` automatically manages the build, so no need to depend on the build target here in make
 test: build
 	@echo Vetting
 	go vet ./...


### PR DESCRIPTION
There is a mark in makefile line 25:
```
`go test` automatically manages the build, so no need to depend on the build target here in make
```
but we need `build` now

<img width="631" height="442" alt="图片" src="https://github.com/user-attachments/assets/792bd8fb-425d-4313-8e27-b20317560775" />

