### PR TITLE
Bump go to 1.26.1

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -10,11 +10,6 @@ jobs:
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
           go-version-file: go.mod
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
-        with:
-          version: v2.5.0
-          args: --config tools/.golangci.yaml
       - run: |
           set -euo pipefail
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ GOOS ?= linux
 GOARCH ?= amd64
 GOFILES = $(shell find . -name \*.go)
 CGO_ENABLED ?= 0
-GOLANGCI_LINT_VERSION ?= v2.5.0
+GOLANGCI_LINT_VERSION ?= v2.10.1
 
 .PHONY: fmt
 fmt:

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/etcd-io/auger
 
-go 1.25.0
+go 1.26
 
-toolchain go1.25.7
+toolchain go1.26.1
 
 require (
 	github.com/google/safetext v0.0.0-20220914124124-e18e3fe012bf


### PR DESCRIPTION
- In the GitHub action, golangci-lint was being run repeatedly; one of them was deleted.
- Golang ci-lint version aligned with etcd