### PR TITLE
bump go 1.26.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d
+FROM docker.io/golang:1.26.4-alpine@sha256:5e5e60ea14e48d2039718813f156ed8ceaf1cee274d9930bde91dcb8cfd90103
 
 RUN apk add --no-cache curl git make && rm -rf /var/cache/apk/*
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/etcd-io/auger
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.4
 
 require (
 	github.com/google/safetext v0.0.0-20220914124124-e18e3fe012bf


### PR DESCRIPTION
Part of https://github.com/etcd-io/etcd/issues/21885