### PR TITLE
augerctl: add --limit option to get command (#92)

### DIFF
--- a/augerctl/command/get_command.go
+++ b/augerctl/command/get_command.go
@@ -31,6 +31,7 @@ type getFlagpole struct {
 	Output    string
 	ChunkSize int64
 	Prefix    string
+	Limit     int64
 }
 
 var getExample = `
@@ -85,6 +86,7 @@ func newCtlGetCommand(f *flagpole) *cobra.Command {
 	cmd.Flags().StringVarP(&flags.Namespace, "namespace", "n", "", "namespace of resource")
 	cmd.Flags().Int64Var(&flags.ChunkSize, "chunk-size", 500, "chunk size of the list pager")
 	cmd.Flags().StringVar(&flags.Prefix, "prefix", "/registry", "prefix to prepend to the resource")
+	cmd.Flags().Int64Var(&flags.Limit, "limit", 0, "max total number of results returned (0 means no limit)")
 
 	return cmd
 }
@@ -118,6 +120,7 @@ func getCommand(ctx context.Context, etcdclient client.Client, flags *getFlagpol
 		client.WithName(targetName, targetNamespace),
 		client.WithGroupResource(targetGr),
 		client.WithChunkSize(flags.ChunkSize),
+		client.WithLimit(flags.Limit),
 		client.WithResponse(printer.Print),
 	}
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -54,6 +54,8 @@ type op struct {
 	// max number of results per clientv3 request.
 	chunkSize int64
 	revision  int64
+	// max total number of results returned. 0 means no limit.
+	limit int64
 }
 
 // OpOption is the option for the operation.
@@ -85,6 +87,14 @@ func WithResponse(response func(kv *KeyValue) error) OpOption {
 func WithChunkSize(chunkSize int64) OpOption {
 	return func(o *op) {
 		o.chunkSize = chunkSize
+	}
+}
+
+// WithLimit sets the max total number of results returned by Get.
+// A value of 0 means no limit.
+func WithLimit(limit int64) OpOption {
+	return func(o *op) {
+		o.limit = limit
 	}
 }
 

--- a/pkg/client/client_get.go
+++ b/pkg/client/client_get.go
@@ -53,6 +53,9 @@ func (c *client) Get(ctx context.Context, prefix string, opOpts ...OpOption) (re
 
 	// it is a key or it is not paging
 	if single || opt.chunkSize == 0 {
+		if opt.limit > 0 {
+			opts = append(opts, clientv3.WithLimit(opt.limit))
+		}
 		resp, err := c.client.Get(ctx, path, opts...)
 		if err != nil {
 			return 0, err
@@ -67,16 +70,26 @@ func (c *client) Get(ctx context.Context, prefix string, opOpts ...OpOption) (re
 
 	// paging for content
 	opts = append(opts, clientv3.WithLimit(opt.chunkSize))
+	var returned int64
 	for key := path; ; {
 		resp, err := c.client.Get(ctx, key, opts...)
 		if err != nil {
 			return 0, err
 		}
 
-		err = iterateList(resp.Kvs, opt.response)
+		kvs := resp.Kvs
+		if opt.limit > 0 {
+			remaining := opt.limit - returned
+			if int64(len(kvs)) > remaining {
+				kvs = kvs[:remaining]
+			}
+		}
+
+		err = iterateList(kvs, opt.response)
 		if err != nil {
 			return 0, err
 		}
+		returned += int64(len(kvs))
 
 		// if revision is not set, it is set to the revision of the first response.
 		if rev == 0 {
@@ -84,6 +97,9 @@ func (c *client) Get(ctx context.Context, prefix string, opOpts ...OpOption) (re
 			opts = append(opts, clientv3.WithRev(resp.Header.Revision))
 		}
 
+		if opt.limit > 0 && returned >= opt.limit {
+			break
+		}
 		if !resp.More {
 			break
 		}

--- a/tests/e2e/get_test.go
+++ b/tests/e2e/get_test.go
@@ -64,3 +64,30 @@ func TestGetWithLimit(t *testing.T) {
 		t.Errorf("Got kind: %s, expected ServiceAccount", got.Kind)
 	}
 }
+
+func TestGetWithoutLimit(t *testing.T) {
+	// Contrast case for TestGetWithLimit: the same serviceaccounts query with no
+	// --limit must return more than one document. This proves --limit 1 genuinely
+	// truncates the result set, rather than the prefix happening to hold a single
+	// record, which would make the TestGetWithLimit assertion pass vacuously.
+	out, err := exec.Command(augerctl,
+		"--endpoints", endpoint,
+		"get", "serviceaccounts",
+	).Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	docs := bytes.Split(bytes.TrimSpace(out), []byte("\n---\n"))
+	if len(docs) <= 1 {
+		t.Errorf("expected more than 1 document without --limit, got %d", len(docs))
+	}
+
+	got := corev1.ServiceAccount{}
+	if err := yaml.Unmarshal(docs[0], &got); err != nil {
+		t.Fatalf("decode first document: %v", err)
+	}
+	if got.Kind != "ServiceAccount" {
+		t.Errorf("Got kind: %s, expected ServiceAccount", got.Kind)
+	}
+}

--- a/tests/e2e/get_test.go
+++ b/tests/e2e/get_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"bytes"
 	"os/exec"
 	"testing"
 
@@ -33,5 +34,33 @@ func TestGet(t *testing.T) {
 
 	if got.Kind != "Service" {
 		t.Errorf("Got service type: %s, expected Service", got.Kind)
+	}
+}
+
+func TestGetWithLimit(t *testing.T) {
+	// serviceaccounts has multiple records across namespaces in a kwok cluster,
+	// so it is a reliable target for verifying --limit truncates the result set.
+	out, err := exec.Command(augerctl,
+		"--endpoints", endpoint,
+		"get", "serviceaccounts",
+		"--limit", "1",
+	).Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The YAML printer emits each object as a document separated by `---`.
+	// With --limit 1 we expect exactly one object document.
+	docs := bytes.Split(bytes.TrimSpace(out), []byte("\n---\n"))
+	if len(docs) != 1 {
+		t.Errorf("expected 1 document with --limit 1, got %d", len(docs))
+	}
+
+	got := corev1.ServiceAccount{}
+	if err := yaml.Unmarshal(docs[0], &got); err != nil {
+		t.Fatalf("decode first document: %v", err)
+	}
+	if got.Kind != "ServiceAccount" {
+		t.Errorf("Got kind: %s, expected ServiceAccount", got.Kind)
 	}
 }


### PR DESCRIPTION
Adds a `--limit N` flag to `augerctl get` to cap the total number of results returned.
Closes #92.

Implementation:
- New `WithLimit(int64)` OpOption on the client package. `0` means no limit (default), preserving existing behavior.
- In the single-key / no-paging branch, the limit is passed through as `clientv3.WithLimit`.
- In the paging branch, results are truncated locally once the accumulated count reaches the limit. The final batch is truncated to the exact remainder.
- New e2e test `TestGetWithLimit` verifies `augerctl get serviceaccounts --limit 1` returns exactly one document.

Useful when scanning a large prefix and only the first N records are needed (e.g. inspecting a few items by hand without paging through everything).