### PR TITLE
Return an error instead of panicking on a short revision key

### DIFF
--- a/pkg/data/data.go
+++ b/pkg/data/data.go
@@ -219,7 +219,11 @@ func getCompactRevision(db *bolt.DB) (int64, error) {
 		}
 		finishedCompactBytes := b.Get(finishedCompactKeyName)
 		if len(finishedCompactBytes) != 0 {
-			compactRev = bytesToRev(finishedCompactBytes).main
+			rev, err := bytesToRev(finishedCompactBytes)
+			if err != nil {
+				return err
+			}
+			compactRev = rev.main
 		}
 		return nil
 	})
@@ -437,10 +441,12 @@ func walk(db *bolt.DB, f func(r revKey, kv *mvccpb.KeyValue) (bool, error)) erro
 		c := b.Cursor()
 
 		for k, v := c.First(); k != nil; k, v = c.Next() {
-			revision := bytesToRev(k)
-			kv := &mvccpb.KeyValue{}
-			err := kv.Unmarshal(v)
+			revision, err := bytesToRev(k)
 			if err != nil {
+				return err
+			}
+			kv := &mvccpb.KeyValue{}
+			if err := kv.Unmarshal(v); err != nil {
 				return err
 			}
 			done, err := f(revision, kv)
@@ -491,15 +497,18 @@ const (
 	markTombstone     byte = 't'
 )
 
-func bytesToRev(bytes []byte) revKey {
+func bytesToRev(bytes []byte) (revKey, error) {
+	if len(bytes) < revBytesLen {
+		return revKey{}, fmt.Errorf("invalid etcd boltdb: revision key must be at least %d bytes, got %d", revBytesLen, len(bytes))
+	}
 	r := revKey{
 		main: int64(binary.BigEndian.Uint64(bytes[0:8])),
-		sub:  int64(binary.BigEndian.Uint64(bytes[9:])),
+		sub:  int64(binary.BigEndian.Uint64(bytes[9:revBytesLen])),
 	}
 	if len(bytes) >= markedRevBytesLen {
-		r.tombstone = bytes[markedRevBytesLen-1] == 't'
+		r.tombstone = bytes[markBytePosition] == markTombstone
 	}
-	return r
+	return r, nil
 }
 
 // ParseFilters parses a comma separated list of '<field>=<value>' filters where each field is

--- a/pkg/data/data_test.go
+++ b/pkg/data/data_test.go
@@ -214,6 +214,42 @@ func TestListKeySummariesMissingKeyBucket(t *testing.T) {
 	}
 }
 
+func TestListKeySummariesShortRevisionKey(t *testing.T) {
+	file := createTestDB(t, func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket(keyBucket)
+		if err != nil {
+			return err
+		}
+		return b.Put([]byte("short"), []byte("value"))
+	})
+
+	_, err := ListKeySummaries(scheme.Codecs, file, nil, ProjectEverything, 0)
+	if err == nil {
+		t.Fatalf("expected error when a revision key is too short")
+	}
+	if !strings.Contains(err.Error(), "revision key must be at least") {
+		t.Fatalf("expected short revision key error, got: %v", err)
+	}
+}
+
+func TestHashByRevisionShortCompactRevision(t *testing.T) {
+	file := createTestDB(t, func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket(metaBucket)
+		if err != nil {
+			return err
+		}
+		return b.Put(finishedCompactKeyName, []byte("short"))
+	})
+
+	_, err := HashByRevision(file, 0)
+	if err == nil {
+		t.Fatalf("expected error when the compact revision value is too short")
+	}
+	if !strings.Contains(err.Error(), "revision key must be at least") {
+		t.Fatalf("expected short revision key error, got: %v", err)
+	}
+}
+
 func TestHashByRevisionMissingMetaBucket(t *testing.T) {
 	file := createTestDB(t, nil)
 


### PR DESCRIPTION
`bytesToRev` length-checks only the tombstone byte. The two reads above it are unguarded, so any entry in the key bucket shorter than 17 bytes takes the process down:

```
panic: runtime error: slice bounds out of range [:8] with capacity 5
github.com/etcd-io/auger/pkg/data.bytesToRev(...)
	pkg/data/data.go:496
github.com/etcd-io/auger/pkg/data.walk.func1(...)
	pkg/data/data.go:440
main.main()
	main.go:26
### CLI EXIT CODE: 2 ###
```

There is no `recover()` anywhere in the non-test code, so this is a hard abort rather than an error. It matters because it fires on exactly the input auger exists to handle: a truncated or damaged database.

This is the same shape as #365, which was the nil-bucket panic one line away in the same `walk` callback. I followed the fix from `737ef47` deliberately, so the error string matches `bucketOrError`'s style and the tests use the existing `createTestDB` helper.

After the change:

```
Error: invalid etcd boltdb: revision key must be at least 17 bytes, got 5
```

exit code 1, and a real fixture database still analyzes normally.

Two call sites are covered, since both can reach it. `walk` handles the key bucket, and `getCompactRevision` reads `finishedCompactRev` from the meta bucket where the existing guard is `len != 0` rather than a length floor. There is a test for each, and both panic without the fix.

While in there I also switched the tombstone read to the `markBytePosition` and `markTombstone` constants that were already declared next to `revBytesLen` but unused.

`bytesToRev` is unexported and the signature change is contained to those two callers. `walk`'s exported behaviour is unchanged, since it already returned an error.

`go build ./...`, `gofmt` and `go test ./pkg/...` are clean.
