### PR TITLE
bump go 1.26.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/etcd-io/auger
 
 go 1.26.0
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/google/safetext v0.0.0-20220914124124-e18e3fe012bf


### PR DESCRIPTION
Part of https://github.com/etcd-io/etcd/issues/22283

Dockerfile dependency PR - https://github.com/etcd-io/auger/pull/513
