### PR TITLE
bump go 1.27.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ GOOS ?= linux
 GOARCH ?= amd64
 GOFILES = $(shell find . -name \*.go)
 CGO_ENABLED ?= 0
-GOLANGCI_LINT_VERSION ?= v2.10.1
+GOLANGCI_LINT_VERSION ?= v2.13.1
 
 .PHONY: fmt
 fmt:

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/etcd-io/auger
 
-go 1.26.0
+go 1.27
 
-toolchain go1.26.6
+toolchain go1.27.0
 
 require (
 	github.com/google/safetext v0.0.0-20220914124124-e18e3fe012bf


### PR DESCRIPTION
~~Part of https://github.com/etcd-io/etcd/issues/22309~~

Edit: Got superseded by Go 1.27 update. Hence updating the same PR. 
Now part of https://github.com/etcd-io/etcd/issues/22329